### PR TITLE
Adaptation for the change of method name in N developer preview 2

### DIFF
--- a/app/src/main/java/com/hitherejoe/pictureinpictureplayground/ui/playback/PlaybackActivity.java
+++ b/app/src/main/java/com/hitherejoe/pictureinpictureplayground/ui/playback/PlaybackActivity.java
@@ -98,7 +98,7 @@ public class PlaybackActivity extends BaseActivity {
     @Override
     public void onPause() {
         super.onPause();
-        if (!inPictureInPicture() && mVideoView.isPlaying()) {
+        if (!isInPictureInPictureMode() && mVideoView.isPlaying()) {
             if (!requestVisibleBehind(true)) {
                 playPause(false);
             } else {
@@ -136,7 +136,7 @@ public class PlaybackActivity extends BaseActivity {
     }
 
     @Override
-    public void onPictureInPictureChanged(boolean inPictureInPicture) {
+    public void onPictureInPictureModeChanged(boolean inPictureInPicture) {
         if (inPictureInPicture) {
             // Hide the controls in picture-in-picture mode.
         } else {

--- a/app/src/main/java/com/hitherejoe/pictureinpictureplayground/ui/playback/PlaybackOverlayFragment.java
+++ b/app/src/main/java/com/hitherejoe/pictureinpictureplayground/ui/playback/PlaybackOverlayFragment.java
@@ -147,7 +147,7 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
                 if (action.getId() == mPlayPauseAction.getId()) {
                     togglePlayback(mPlayPauseAction.getIndex() == PlayPauseAction.PLAY);
                 } else if (action.getId() == mPictureInPictureAction.getId()) {
-                    getActivity().enterPictureInPicture();
+                    getActivity().enterPictureInPictureMode();
                     return;
                 }
                 if (action instanceof PlaybackControlsRow.MultiAction) {


### PR DESCRIPTION
Hi,

This is the patch to avoid the build error caused by the method name change in N developer preview 2.

(source)
http://developer.android.com/shareables/preview/n-preview-2-docs.zip 

Class android.app.Activity
- Removed Methods
  - void **enterPictureInPicture**()  
  - boolean inMultiWindow()  
  - boolean **inPictureInPicture**()  
  - void onMultiWindowChanged(boolean)  
  - void **onPictureInPictureChanged**(boolean)  
  - void onProvideKeyboardShortcuts(List<KeyboardShortcutGroup>, Menu)  
  - void overlayWithDecorCaption(boolean)  
- Added Methods
  - void **enterPictureInPictureMode**()  
  - boolean isInMultiWindowMode()  
  - boolean **isInPictureInPictureMode**()  
  - boolean isOverlayWithDecorCaptionEnabled()  
  - void onMultiWindowModeChanged(boolean)  
  - void **onPictureInPictureModeChanged**(boolean)  
  - void setOverlayWithDecorCaptionEnabled(boolean)

Regards.
